### PR TITLE
query ch map and status by timestamp

### DIFF
--- a/src/legend_data_monitor/subsystem.py
+++ b/src/legend_data_monitor/subsystem.py
@@ -23,11 +23,26 @@ class Subsystem:
 
     Options for kwargs
 
-    setup=
+    dataset=
         dict with the following keys:
             - 'experiment' [str]: 'L60' or 'L200'
-            - 'period' [str]: 'pXX' e.g. p02
-    Or input kwargs separately experiment=, period=
+            - 'path' [str]: < move description here from get_data() >
+            - 'version' [str]: < move description here from get_data() >
+            - 'type' [str]: 'phy' or 'cal'
+            - the following key(s) depending in time selection
+                1) 'start' : <start datetime>, 'end': <end datetime> where <datetime> input is of format 'YYYY-MM-DD hh:mm:ss'
+                2) 'window'[str]: time window in the past from current time point, format: 'Xd Xh Xm' for days, hours, minutes
+                2) 'timestamps': str or list of str in format 'YYYYMMDDThhmmssZ'
+                3) 'runs': int or list of ints for run number(s)  e.g. 10 for r010
+    Or input kwargs separately path=, version=, type=; start=&end=, or window=, or timestamps=, or runs=
+
+    Experiment is needed to know which channel belongs to the pulser Subsystem, AUX0 (L60) or AUX1 (L200)
+    Selection range is needed for the channel map and status information at that time point, and should be the only information needed,
+        however, pylegendmeta only allows query .on(timestamp=...) but not .on(run=...);
+        therefore, to be able to get info in case of `runs` selection, we need to know
+        path, version, and run type to look up first timestamp of the run
+
+    Might set default "latest" for version, but gotta be careful.
     """
 
     def __init__(self, sub_type: str, **kwargs):
@@ -43,28 +58,82 @@ class Subsystem:
 
         # if setup= kwarg was provided, get dict provided
         # otherwise kwargs is itself already the dict we need with experiment= and period=
-        setup_info = kwargs["setup"] if "setup" in kwargs else kwargs
-        experiments = ["L200", "L60"]
-        if (
-            "experiment" not in setup_info
-            or not setup_info["experiment"] in experiments
-        ):
-            utils.logger.error("Tell Subsystem valid experiment it belongs to!")
-            utils.logger.error(self.__doc__)
-            return
-        if "period" not in setup_info or not setup_info["period"][0] == "p":
-            utils.logger.error("Tell Subsystem valid period it belongs to!")
+        data_info = kwargs["dataset"] if "dataset" in kwargs else kwargs
+
+        # -------------------------------------------------------------------------
+        # check validity
+        # -------------------------------------------------------------------------
+
+        if "experiment" not in data_info:
+            utils.logger.error("Provide experiment name!")
             utils.logger.error(self.__doc__)
             return
 
+        if "type" not in data_info:
+            utils.logger.error("Provide data type!")
+            utils.logger.error(self.__doc__)
+            return
+
+        # convert to list for convenience
+        # ! currently not possible with channel status
+        # if isinstance(data_info["type"], str):
+        #     data_info["type"] = [data_info["type"]]
+
+        data_types = ["phy", "cal"]
+        # ! currently not possible with channel status
+        # for datatype in data_info["type"]:
+        # if datatype not in data_types:
+        if not data_info["type"] in data_types:
+            utils.logger.error("Invalid data type provided!")
+            utils.logger.error(self.__doc__)
+            return
+
+        if "path" not in data_info:
+            utils.logger.error("Provide path to data!")
+            utils.logger.error(self.__doc__)
+            return
+        if not os.path.exists(data_info["path"]):
+            utils.logger.error("The data path you provided does not exist!")
+            return
+
+        if "version" not in data_info:
+            utils.logger.error("Provide pygama version!")
+            utils.logger.error(self.__doc__)
+            return
+
+        if not os.path.exists(os.path.join(data_info["path"], data_info["version"])):
+            utils.logger.error("Provide valid pygama version!")
+            utils.logger.error(self.__doc__)
+            return
+
+        # validity of time selection will be checked in utils
+
+        # ? create a checking function taking dict in
+
         # -------------------------------------------------------------------------
-        # get channel map for this subsystem
+        # get channel info for this subsystem
         # -------------------------------------------------------------------------
 
-        self.channel_map = self.get_channel_map(setup_info)  # pd.DataFrame
+        # needed to know which AUX channel is pulser
+        self.experiment = data_info["experiment"]
+        # need to remember for channel status query
+        # ! now needs to be single !
+        self.datatype = data_info["type"]
+        # need to remember for DataLoader config
+        self.path = data_info["path"]
+        self.version = data_info["version"]
+
+        self.timerange, self.first_timestamp = utils.get_query_times(**kwargs)
+
+        # None will be returned if something went wrong
+        if not self.timerange:
+            utils.logger.error(self.get_data.__doc__)
+            return
+
+        self.channel_map = self.get_channel_map()  # pd.DataFrame
 
         # add column status to channel map stating On/Off
-        self.get_channel_status(setup_info)
+        self.get_channel_status()
 
         # -------------------------------------------------------------------------
         # K lines
@@ -80,75 +149,14 @@ class Subsystem:
         # have something before get_data() is called just in case
         self.data = pd.DataFrame()
 
-    def get_data(
-        self, parameters: typing.Union[str, list_of_str, tuple_of_str] = (), **kwargs
-    ):
+    def get_data(self, parameters: typing.Union[str, list_of_str, tuple_of_str] = ()):
         """
         Get data for requested parameters from DataLoader and "prime" it to be ready for analysis.
 
         parameters: single parameter or list of parameters to load.
             If empty, only default parameters will be loaded (channel, timestamp; baseline and wfmax for pulser)
-
-        Available kwargs:
-
-        dataset=
-            dict with the following contents:
-                - 'type' [str or list of str]: type of data to load e.g. 'phy', 'cal', or ['phy', 'cal']
-                - 'path' [str]: path to prod-ref folder (in which is the structure vXX.XX/generated/tier/...) -> needed only for get_data
-                - 'version' [str]: version of pygama vXX.XX e.g. 'v06.00'
-                - 'selection' [dict]: dict with fields depending on selection options
-                    1) 'start' : <start datetime>, 'end': <end datetime> where <datetime> input is of format 'YYYY-MM-DD hh:mm:ss'
-                    2) 'window'[str]: time window in the past from current time point, format: 'Xd Xh Xm' for days, hours, minutes
-                    2) 'timestamps': str or list of str in format 'YYYYMMDDThhmmssZ'
-                    3) 'runs': int or list of ints for run number(s)  e.g. 10 for r010
-        Or input kwargs separately type=, path=, version=; start=&end, or timestamp=, or runs=
-
-        Might set default v06.00 for version, but gotta be careful.
         """
         utils.logger.info("... getting data")
-
-        # if dataset= kwarg was provided, get the dict provided
-        # otherwise kwargs itself is already the dict we need with type=, path=, version=; start=&end= or timestamps= or runs=
-        # we need this dict only for type/path/version (will also contain selection info, but don't care about that)
-        data_info = kwargs["dataset"] if "dataset" in kwargs else kwargs
-
-        # -------------------------------------------------------------------------
-        # check validity
-        # -------------------------------------------------------------------------
-
-        if "type" not in data_info:
-            utils.logger.error("Provide data type!")
-            utils.logger.error(self.get_data.__doc__)
-            return
-
-        # convert to list for convenience
-        if isinstance(data_info["type"], str):
-            data_info["type"] = [data_info["type"]]
-
-        data_types = ["phy", "cal"]
-        for datatype in data_info["type"]:
-            if datatype not in data_types:
-                utils.logger.error("Invalid data type provided!")
-                utils.logger.error(self.get_data.__doc__)
-                return
-
-        if "path" not in data_info:
-            utils.logger.error("Provide path to data!")
-            utils.logger.error(self.get_data.__doc__)
-            return
-        if not os.path.exists(data_info["path"]):
-            utils.logger.error("The data path you provided does not exist!")
-            return
-
-        if "version" not in data_info:
-            utils.logger.error("Provide pygama version!")
-            utils.logger.error(self.get_data.__doc__)
-            return
-
-        if not os.path.exists(os.path.join(data_info["path"], data_info["version"])):
-            utils.logger.error("Provide valid pygama version!")
-            utils.logger.error(self.get_data.__doc__)
-            return
 
         # -------------------------------------------------------------------------
         # Set up DataLoader config
@@ -161,9 +169,7 @@ class Subsystem:
 
         # --- set up DataLoader config
         # needs to know path and version from data_info
-        dlconfig, dbconfig = self.construct_dataloader_configs(
-            params_for_dataloader, data_info
-        )
+        dlconfig, dbconfig = self.construct_dataloader_configs(params_for_dataloader)
 
         # --- set up DataLoader
         dl = DataLoader(dlconfig, dbconfig)
@@ -172,41 +178,27 @@ class Subsystem:
         # Set up query
         # -------------------------------------------------------------------------
 
-        # --- set up time range
+        # if querying by run, time word is 'run'; otherwise 'timestamp'; is the key of the timerange dict
+        time_word = list(self.timerange.keys())[0]
 
-        # needs kwargs dataset={'selection': {...}} or separately start=&end=, or timestamps=, or runs= <- already in kwargs here
-        # returns dict {'start: timestamp1, 'end': timestamp2} or list of runs/keys to get
-        # it will also check the validity of the selection arguments
-        dataloader_timerange = utils.get_dataloader_timerange(**kwargs)
-        # get_dataloader_timerange() will return None if there was an error -> exit
-        if not dataloader_timerange:
-            utils.logger.error(self.get_data.__doc__)
-            return
-
-        # if querying by run, need different query word than by timestamp
-        # in case of runs, format is 'rXXX', and it will be a list
-        time_word = (
-            "run"
-            if isinstance(dataloader_timerange, list)
-            and dataloader_timerange[0][0] == "r"
-            else "timestamp"
-        )
-        if isinstance(dataloader_timerange, dict):
-            # query by (timestamp >= ) and (timestamp <=) if format {start: end:}
-            query = f"({time_word} >= '{dataloader_timerange['start']}') and ({time_word} <= '{dataloader_timerange['end']}')"
+        if "start" in self.timerange[time_word]:
+            # query by (run/timestamp >= ) and (run/timestamp <=) if format {start: end:}
+            query = f"({time_word} >= '{self.timerange[time_word]['start']}') and ({time_word} <= '{self.timerange[time_word]['end']}')"
         else:
             # query by (run/timestamp == ) or (run/timestamp == ) if format [list of runs/timestamps]
             query = " or ".join(
                 f"({time_word} == '" + run_or_timestamp + "')"
-                for run_or_timestamp in dataloader_timerange
+                for run_or_timestamp in self.timerange[time_word]
             )
 
         # --- cal or phy data or both
-        query += (
-            " and ("
-            + " or ".join("(type == '" + x + "')" for x in data_info["type"])
-            + ")"
-        )
+        # ! not possible to load both phy and cal for now, based on how channel status works
+        # query += (
+        #     " and ("
+        #     + " or ".join("(type == '" + x + "')" for x in self.type)
+        #     + ")"
+        # )
+        query += f" and (type == '{self.datatype}')"
 
         # !!!! QUICKFIX FOR R010
         query += " and (timestamp != '20230125T222013Z')"
@@ -309,7 +301,7 @@ class Subsystem:
 
         self.data = self.data.reset_index()
 
-    def get_channel_map(self, setup_info: dict):
+    def get_channel_map(self):
         """
         Build channel map for given subsystem.
 
@@ -326,9 +318,9 @@ class Subsystem:
         # load full channel map of this exp and period
         # -------------------------------------------------------------------------
 
-        ex = "l" + setup_info["experiment"][1:].zfill(3)  # l060 or l200
-        json_file = f"{ex}-{setup_info['period']}-r%-T%-all-config.json"
-        full_channel_map = LEGEND_META.hardware.configuration.channelmaps[json_file]
+        full_channel_map = LEGEND_META.hardware.configuration.channelmaps.on(
+            timestamp=self.first_timestamp
+        )
 
         df_map = pd.DataFrame(
             columns=["name", "location", "channel", "position", "cc4_id", "cc4_channel"]
@@ -343,7 +335,7 @@ class Subsystem:
         def is_subsystem(entry):
             # special case for pulser
             if self.type == "pulser":
-                pulser_ch = 0 if setup_info["experiment"] == "L60" else 1
+                pulser_ch = 0 if self.experiment == "L60" else 1
                 return entry["system"] == "auxs" and entry["daq"]["fcid"] == pulser_ch
             # for geds or spms
             return entry["system"] == self.type
@@ -380,7 +372,7 @@ class Subsystem:
             df_map.at[ch, "position"] = (
                 0 if self.type == "pulser" else entry_info["location"]["position"]
             )
-            # CC4 information
+            # CC4 information - will be None for L60 or spms -> put an if condition to avoid?
             df_map.at[ch, "cc4_id"] = (
                 entry_info["electronics"]["cc4"]["id"] if self.type == "geds" else None
             )
@@ -403,7 +395,7 @@ class Subsystem:
         df_map = df_map.sort_values("channel")
         return df_map
 
-    def get_channel_status(self, setup_info: dict):
+    def get_channel_status(self):
         """
         Add status column to channel map with On/Off for software status.
 
@@ -414,21 +406,12 @@ class Subsystem:
         utils.logger.info("... getting channel status")
 
         # -------------------------------------------------------------------------
-        # load full status map of this exp and period
+        # load full status map of this time selection
         # -------------------------------------------------------------------------
 
-        run = {"L60": "%", "L200": "010"}[setup_info["experiment"]]
-        # L60-pXX-r%-... for L60, L200-pXX-r010-... for L200
-        json_file = f"{setup_info['experiment']}-{setup_info['period']}-r{run}-T%-all-config.json"
-        full_status_map = LEGEND_META.dataprod.config[json_file][
-            "hardware_configuration"
-        ]["channel_map"]
-
-        # ----- from Katha
-        # chstatmap = self.lmeta.dataprod.config.on(timestamp=timestamp, system='phy')['hardware_configuration']['channel_map']
-        # chstat = chstatmap.get('ch'+f"{val.daq.fcid:03d}", {}).get("software_status", "Off")
-        # if chstat == "On":
-        # ....
+        full_status_map = LEGEND_META.dataprod.config.on(
+            timestamp=self.first_timestamp, system=self.datatype
+        )["hardware_configuration"]["channel_map"]
 
         # AUX channels are not in status map, so at least for pulser need default On
         self.channel_map["status"] = "On"
@@ -484,7 +467,7 @@ class Subsystem:
         # some parameters might be repeated twice - remove
         return list(np.unique(params))
 
-    def construct_dataloader_configs(self, params: list_of_str, data_info: dict):
+    def construct_dataloader_configs(self, params: list_of_str):
         """
         Construct DL and DB configs for DataLoader based on parameters and which tiers they belong to.
 
@@ -512,9 +495,7 @@ class Subsystem:
         # -------------------------------------------------------------------------
 
         dict_dbconfig = {
-            "data_dir": os.path.join(
-                data_info["path"], data_info["version"], "generated", "tier"
-            ),
+            "data_dir": os.path.join(self.path, self.version, "generated", "tier"),
             "tier_dirs": {},
             "file_format": {},
             "table_format": {},


### PR DESCRIPTION
Implemented querying channel map and status by timestamp; in case of run= time selection, look for first timestamp based on path, version and data type, as pylegendmeta does not (yet?) allow querying channel map/status by keyword run=, only timestamp.

This implementation does not allow multiple data types, as specific data type is needed to query channel status. Note: in principle it seems to me that data type is not needed to query channel status, as, same as for channel map, a timestamp uniquely defines not only period and run, but also data type.

This implementation will result in a crash if multiple runs are provided, and the channel status is different in the later one, as status will be checked by earliest timestamp, as DataLoader might crash not finding channel that was on in earlier run in the later run. Same for timestamp range that spans multiple runs.

Might implement a check of earliest and latest timestamp to see if channel map is the same, and proceed if yes.